### PR TITLE
Removed the lifepod biome from the safe shallows (for compatability with DeathRun)

### DIFF
--- a/Player Events/Biome.cs
+++ b/Player Events/Biome.cs
@@ -29,7 +29,7 @@ namespace TransitionRandomiser.Player_Events
     class BiomeHandler
     {
         //public static Biome LIFEPOD = new Biome("lifepod", new string[] { "lifepod" });
-        public static Biome SAFESHALLOWS = new Biome("Safe Shallows", new string[] { "safeshallows", "lifepod" });
+        public static Biome SAFESHALLOWS = new Biome("Safe Shallows", new string[] { "safeshallows", /*"lifepod"*/ });
         public static Biome GRASSYPLATEAUS = new Biome("Grassy Plateaus", new string[] { "grassyplateaus" });
         public static Biome KELPFOREST = new Biome("Kelp Forest", new string[] { "kelpforest" });
         public static Biome JELLYSHROOMCAVE = new Biome("Jellyshroom Cave", new string[] { "jellyshroomcaves" });


### PR DESCRIPTION
DeathRun has this random start location feature, and if the lifepod isn't in the safe shallows, you'd get teleported when entering it.
I've tested it a little and it should work now.